### PR TITLE
Receive context using asio::query

### DIFF
--- a/include/dbus/filter.hpp
+++ b/include/dbus/filter.hpp
@@ -34,7 +34,7 @@ class filter {
   filter(connection& c, ASIO_MOVE_ARG(MessagePredicate) p)
       : connection_(c),
         predicate_(ASIO_MOVE_CAST(MessagePredicate)(p)),
-        queue_(connection_.get_executor().context()) {
+        queue_(asio::query(connection_.get_executor(), asio::execution::context)) {
     connection_.new_filter(*this);
   }
 
@@ -44,7 +44,7 @@ class filter {
   inline ASIO_INITFN_RESULT_TYPE(MessageHandler, void(asio::error_code, message))
   async_dispatch(ASIO_MOVE_ARG(MessageHandler) handler) {
     // begin asynchronous operation
-    connection_.get_implementation().start(connection_.get_executor().context());
+    connection_.get_implementation().start(asio::query(connection_.get_executor(), asio::execution::context));
 
     return queue_.async_pop(ASIO_MOVE_CAST(MessageHandler)(handler));
   }

--- a/test/avahi.cpp
+++ b/test/avahi.cpp
@@ -33,7 +33,7 @@ TEST(AvahiTest, GetHostNameCoAwait) {
     asio::co_spawn(io, [&is_ok]() -> awaitable_io<void>
     {
         auto ex = co_await asio::this_coro::executor;
-        auto& io = ex.context();
+        auto& io = asio::query(ex, asio::execution::context);
 
         dbus::endpoint test_daemon("org.freedesktop.Avahi", "/",
                                    "org.freedesktop.Avahi.Server");


### PR DESCRIPTION
Receiving context from executor using context() method doesn't work in case ASIO_NO_TS_EXECUTORS is enabled. 
Use modern way to extract context: asio::query(ex, asio::execution::context) 